### PR TITLE
コマンドが全く渡されなかった場合に対応

### DIFF
--- a/system/script_compiler.rb
+++ b/system/script_compiler.rb
@@ -42,7 +42,7 @@ class ScriptCompiler
     
     @alias_list = []
     
-    @script_storage = eval(File.open(file_path, "r:UTF-8", &:read))
+    @script_storage = eval(File.open(file_path, "r:UTF-8", &:read)) || []
   end
 
   def impl(command_name, default_class, target, option, sub_options = {}, &block)


### PR DESCRIPTION
コマンドが全く無いとnilが渡される
その場合に空の配列を代入するようにした