### PR TITLE
IF文ELSE節にコマンドが全く無かった場合に対応

### DIFF
--- a/system/control_container.rb
+++ b/system/control_container.rb
@@ -430,7 +430,7 @@ class Control
       eval_block(options[:then])
     #else節がある場合
     elsif options[:else]
-      eval_block(options[:else])
+      eval_block(options[:else]) if options[:else] #else節の中に何も無かった場合はスルー
     end
     return :continue
   end


### PR DESCRIPTION
option[:else]にnilが渡される
その場合はeval_blockをしないようにした