### PR TITLE
blockコマンドをaboutに名前差し替え

### DIFF
--- a/system/script_compiler.rb
+++ b/system/script_compiler.rb
@@ -237,7 +237,12 @@ class ScriptCompiler
   #画像の差し替え
   impl_option_options_block :image_change, :ImageControl
 
-  impl_block :block
+  #他の部分でblockという変数を使っているので一応の為変更
+  #スクリプト上でもこちらの方が分かりやすいかも
+  #impl_block :about  #↓
+  def about(target, &block)
+    impl(:block, :Anonymous, target, nil, &block)
+  end
 
 =begin
   #TODO：一時的にprocedureの機能を停止する


### PR DESCRIPTION
引数に&blockを用いている部分が有り、
blockメソッドが存在すると、引数を取り忘れたり名前を間違ったりしてもSyntaxErrorではなく別のエラーが出る
それを回避