### PR TITLE
_YIELD_の不具合2件修正

### DIFF
--- a/system/control_container.rb
+++ b/system/control_container.rb
@@ -99,7 +99,8 @@ class Control
     #ブロックが付与されているなら読み込んで登録する
     if inner_options[:block]
       @command_list = @script_compiler.commands(
-                          options, 
+                          options,
+                          inner_options[:block_stack],
                           &inner_options[:block])
     end
 
@@ -577,8 +578,11 @@ class Control #ユーザー定義関数操作
   #関数ブロックを実行する
   def command__YIELD_(options, inner_options)
     return unless inner_options[:block_stack]
-    
-    eval_block(options, &inner_options[:block_stack].pop)
+
+    block = inner_options[:block_stack].pop
+    block_stack = inner_options[:block_stack].empty? ? nil : inner_options[:block_stack]
+
+    eval_block(options, block_stack, &block)
   end
 
   #コマンドを再定義する


### PR DESCRIPTION
以下2件の不具合を修正しました。どっちもblock_stackの渡し忘れです。
・ビルトインコマンドに渡したブロックから_YIELD_できない
・ユーザ定義コマンドで多段_YIELD_した場合に2段目以降が実行されない
