### PR TITLE
Clickableモジュール機能拡張

### DIFF
--- a/scenario/scenario_collision.rb
+++ b/scenario/scenario_collision.rb
@@ -1,0 +1,37 @@
+#! ruby -E utf-8
+
+#ボタンコントロール
+_CREATE_ :ButtonControl, 
+        :x_pos => 150, 
+        :y_pos => 150, 
+        :width => 256,
+        :height => 256,
+        :id=>:button1,
+        :collision=>[128,128,128] do
+  image :entity=>Image.new(256,256).circle_fill(128,128,128,C_BLUE).draw_font(80, 120, "NORMAL", Font.default),
+        :id=>:normal
+  image :entity=>Image.new(256,256).circle_fill(128,128,128,C_YELLOW).draw_font(80, 120, "OVER", Font.default, C_BLACK),
+        :id=>:over, :visible => false
+  image :entity=>Image.new(256,256).circle_fill(128,128,128,C_GREEN).draw_font(80, 120, "DOWN", Font.default),
+        :id=>:key_down, :visible => false
+  on_mouse_over do
+    set :normal, visible: false
+    set :over,   visible: true
+    set :key_down, visible: false
+  end
+  on_mouse_out do
+    set :over,   visible: false
+    set :normal, visible: true
+    set :key_down, visible: false
+  end
+  on_key_down do
+    set :over,   visible: false
+    set :normal, visible: false
+    set :key_down, visible: true
+  end
+  on_key_up do
+    set :key_down, visible: false
+    set :normal, visible: false
+    set :over,   visible: true
+  end
+end

--- a/system/module_clickable.rb
+++ b/system/module_clickable.rb
@@ -52,6 +52,16 @@ module Clickable
     @width  = options[:width]  || 0 #横幅
     @height = options[:height] || 0 #縦幅
 
+    @collision_sprite = Sprite.new
+    if options[:collision]
+      @collision_sprite.collision = options[:collision]
+    else
+      @collision_sprite.collision = [0, 0, @width-1, @height-1]
+    end
+
+    @mouse_sprite = Sprite.new
+    @mouse_sprite.collision = [0, 0]
+
     @child_controls_draw_to_entity = false
     @over = false
     @out = true
@@ -72,10 +82,9 @@ module Clickable
     @y = Input.mouse_pos_y
 
     #描画範囲内かどうか
-    if (@x_pos < @x              and 
-        @x     < @x_pos + @width and
-        @y_pos < @y              and 
-        @y     < @y_pos + @height)
+    @collision_sprite.x, @collision_sprite.y = @x_pos, @y_pos
+    @mouse_sprite.x, @mouse_sprite.y = @x, @y
+    if (@mouse_sprite === @collision_sprite)
       #イベント起動済みフラグクリア
       @out = false
 


### PR DESCRIPTION
Clickableモジュールを修正してSpriteを使って判定するようにしてみました。
元が各オブジェクト個別にマウス座標を取得していたので、同様に個別にマウスカーソル用Spriteを持たせています。
また、:collisionオプションでSprite#collision=用の配列を渡すことで判定する形状を変更することができます。
サンプルシナリオも作っておきました。
ご査収ください。