### PR TITLE
ScriptCompilerからimpl_defineを削除してmethod_missing内でrespond_to?して振り分ける方式に変更

### DIFF
--- a/system/button_control.rb
+++ b/system/button_control.rb
@@ -31,10 +31,6 @@ require_relative './script_compiler.rb'
 #[The zlib/libpng License http://opensource.org/licenses/Zlib]
 ###############################################################################
 
-#コマンド宣言
-class ScriptCompiler
-end
-
 #ボタンコントロール
 class ButtonControl  < Control
   include Drawable

--- a/system/control_container.rb
+++ b/system/control_container.rb
@@ -52,7 +52,7 @@ class Control #公開インターフェイス
       @user_data = {}
     end
 
-    @script_compiler = ScriptCompiler.new
+    @script_compiler = ScriptCompiler.new(self)
 
     #コントロールのID(省略時は自身のクラス名とする)
     @id = options[:id] || ("Anonymous_" + self.class.name).to_sym

--- a/system/module_clickable.rb
+++ b/system/module_clickable.rb
@@ -32,18 +32,7 @@ require_relative './control_container.rb'
 #[The zlib/libpng License http://opensource.org/licenses/Zlib]
 ###############################################################################
 
-#コマンド宣言
-class ScriptCompiler
-  impl_define :on_mouse_over
-  impl_define :on_mouse_out
-  impl_define :on_key_down
-  impl_define :on_key_down_out
-  impl_define :on_key_up
-  impl_define :on_key_up_out
-end
-
 #クリックイベントが発生するコントロールの基底クラス
-#TODO：将来的にはSpriteクラスを使い、任意形状でカーソルとの当たり判定が出来るようにする
 module Clickable
   def initialize(options, inner_options, root_control)
     @x_pos = options[:x_pos] || 0 #描画Ｘ座標

--- a/system/script_compiler.rb
+++ b/system/script_compiler.rb
@@ -31,6 +31,11 @@ require 'dxruby'
 ###############################################################################
 
 class ScriptCompiler
+
+  def initialize(object)
+    @object = object
+  end
+
   #ヘルパーメソッド群
   def commands(argument, block_stack = nil, &block)
     @command_list = []
@@ -49,88 +54,24 @@ class ScriptCompiler
 
       self.instance_exec(**argument, &block)
     end
-    return  @command_list || []
+    return  @command_list
   end
 
-  def impl(command_name, option, **sub_options, &block)
-    #キー名無しオプションがある場合はコマンド名をキーに設定する
-    sub_options[:_ARGUMENT_] = option if option != nil
+  def method_missing(command_name, option = nil, **options, &block)
+    if @object.respond_to?("command_" + command_name.to_s, true) || command_name == :end_frame
+      # 組み込みコマンドがある場合はそのまま呼ぶ
+      options[:_ARGUMENT_] = option if option != nil
+    else
+      # 組み込みコマンドが無い場合は_CALL_に差し替える
+      options[:_FUNCTION_ARGUMENT_] = option if option
+      options[:_ARGUMENT_] = command_name
+      command_name = :_CALL_
+    end
 
-    system_options = {:block_stack => @block_stack}
-    system_options[:block] = block if block
+    inner_options = {:block_stack => @block_stack}
+    inner_options[:block] = block if block
 
     #コマンドを登録する
-    @command_list.push([command_name,sub_options, system_options])
+    @command_list.push([command_name, options, inner_options])
   end
-
-  #コマンドに対応するメソッドを生成する。
-  def self.impl_define(command_name)
-    define_method(command_name) do |option = nil, **option_hash, &block|
-      impl(command_name, option, option_hash, &block)
-    end
-  end
-
-  #プロシージャー登録されたコマンドが宣言された場合にここで受ける
-  def method_missing(user_function_name, option = nil, **options, &block)
-    #無名引数がある場合、関数名をキーに格納する
-    options[:_FUNCTION_ARGUMENT_] = option if option
-    #TODO：存在しないメソッドが実行される問題について要検討
-    impl(:_CALL_, user_function_name, options, &block)
-  end
-
-  impl_define :end_frame
-
-  #ＳＥの再生と停止（暫定）
-  impl_define :se_play
-  impl_define :se_stop
-
-  #移動
-  impl_define :move
-  impl_define :move_line
-  impl_define :move_line_with_skip
-
-  #フェードトランジション
-  impl_define :transition_fade
-
-  impl_define :change_default_target
-
-  impl_define :_SET_
-  impl_define :_SET_DATA_
-
-  impl_define :_SEND_
-
-  #スクリプトファイルの挿入
-  impl_define :_INCLUDE_
-
-  #コントロールの生成
-  impl_define :_CREATE_
-  #コントロールの削除
-  impl_define :_DELETE_
-
-  #各種ウェイト処理
-  impl_define :_WAIT_ #条件を満たさない限りブロックを実行して待機
-  impl_define :_CHECK_ #条件を満たしたらブロックを実行
-
-  #制御構文 if系
-  impl_define :_IF_ #廃止予定
-  impl_define :_THEN_ #廃止予定
-  impl_define :_ELSE_ #廃止予定
-  impl_define :_ELSIF_ #廃止予定
-
-  #case-when文
-  impl_define :_CASE_ #廃止予定
-  impl_define :_WHEN_ #廃止予定
-
-  #while文
-  impl_define :_WHILE_
-  impl_define :_BREAK_
-
-  #ユーザー定義コマンド
-  impl_define :_DEFINE_
-  impl_define :_CALL_
-  impl_define :_YIELD_
-  impl_define :_END_SCOPE_
-
-  #実行時評価
-  impl_define :_EVAL_
 end

--- a/system/text_page_control.rb
+++ b/system/text_page_control.rb
@@ -38,50 +38,6 @@ require_relative './char_control'
 #汎用テキストマネージャクラス
 ###############################################################################
 
-#コマンド宣言
-class ScriptCompiler
-  #TODO:これらはtext_layer内に動作を限定できないか？
-
-  #テキスト関連
-
-  #文字
-  impl_define :char
-  #文字列
-  impl_define :_TEXT_
-
-  impl_define :_LINE_FEED_
-  #改ページ
-  impl_define :_FLUSH_
-=begin
-  #インデント設定
-  impl_define :indent,                :TextPageControl
-  #改行
-  #画像スタック
-  impl_define :graph,                 :TextPageControl
-
-  #文字描画速度の設定
-  impl_define :delay,                 :TextPageControl
-
-  #ルビ文字の出力
-  impl_define :rubi_char,             :TextPageControl
-
-  #複数ルビ文字列の割り付け
-  impl_define :rubi,                  :TextPageControl
-
-  #フォント設定の更新
-  #現在値をリセット
-  impl_define :reset_font_config,     :TextPageControl
-
-  #スタイル設定の更新
-  #現在値をリセット
-  impl_define :reset_style_config,    :TextPageControl
-
-  #その他制御系
-  #レンダリング済みフォントの登録
-  impl_define :map_image_font,        :TextPageControl
-=end
-end
-
 class TextPageControl < Control
   include Movable #移動関連モジュール
   include Drawable #描画関連モジュール


### PR DESCRIPTION
Rubyレベルの組み込みコマンド定義の名前空間が司スクリプト上でも影響するようになります。