### PR TITLE
内部関数をオブジェクト単位に定義する

### DIFF
--- a/scenario/scenario_inner_function.rb
+++ b/scenario/scenario_inner_function.rb
@@ -1,0 +1,55 @@
+#! ruby -E utf-8
+
+#ボタンコントロール
+_CREATE_ :ButtonControl, 
+        :x_pos => 0, 
+        :y_pos => 0, 
+        :width => 256,
+        :height => 256,
+        :id=>:button1 do
+  image :file_path=>"./sozai/button_normal.png", 
+        :id=>:normal
+  #内部関数の定義
+  _DEFINE_ :func do
+    move_line x: 500, y: 0,   count:0, frame: 60, start_x: 0,   start_y: 0
+    wait_command :move_line
+  end
+end
+
+#ボタンコントロール
+_CREATE_ :ButtonControl, 
+        :x_pos => 0, 
+        :y_pos => 0, 
+        :width => 256,
+        :height => 256,
+        :id=>:button2 do
+  image :file_path=>"./sozai/button_normal.png", 
+        :id=>:normal
+  #内部関数の定義
+  _DEFINE_ :func do
+    move_line x: 150, y: 500,   count:0, frame: 60, start_x: 0,   start_y: 0
+    wait_command :move_line
+  end
+end
+
+#ボタンコントロール
+_CREATE_ :ButtonControl, 
+        :x_pos => 0, 
+        :y_pos => 0, 
+        :width => 100,
+        :height => 100,
+        :id=>:button3 do
+  image :entity=>Image.new(100,100,C_WHITE).draw_font(10, 10, "押す", Font.default, C_BLACK),
+        :id=>:normal
+
+  # 「押す」を押すと2つのボタンのfunc関数を呼ぶが、それぞれ違う実装になっているので別々に動く
+  on_key_down do
+    _SEND_ :button1, root:true do
+      func
+    end
+    _SEND_ :button2, root:true do
+      func
+    end
+  end
+end
+

--- a/system/script_compiler.rb
+++ b/system/script_compiler.rb
@@ -32,8 +32,9 @@ require 'dxruby'
 
 class ScriptCompiler
 
-  def initialize(object)
-    @object = object
+  def initialize(control, root_control)
+    @control = control
+    @root_control = root_control
   end
 
   #ヘルパーメソッド群
@@ -58,7 +59,9 @@ class ScriptCompiler
   end
 
   def method_missing(command_name, option = nil, **options, &block)
-    if @object.respond_to?("command_" + command_name.to_s, true) || command_name == :end_frame
+    function = @control.function_list[command_name] || @root_control.function_list[command_name]
+
+    if (!function && @control.respond_to?("command_" + command_name.to_s, true)) || command_name == :end_frame
       # 組み込みコマンドがある場合はそのまま呼ぶ
       options[:_ARGUMENT_] = option if option != nil
     else


### PR DESCRIPTION
ユーザ関数リストをオブジェクトごとに持つようにして、同じ名前で別の関数を作れるようにしました。
ポリモーフィングできます。
こんなふうにしたいと言ってたような気がするので作ってみましたが、思ってたのと違うなら却下してくださいまし。