### PR TITLE
Ayame対応

### DIFF
--- a/sample/sample_1_16.tks
+++ b/sample/sample_1_16.tks
@@ -5,9 +5,10 @@
 キーを押すと再生します
 
 @	test01{
-@		_SET_ loop_count: -1
-@		_MOVE_ 180, volume: [0,230]
+@		_SET_ loop_count: 0
+@		_MOVE_ 180, volume: [0,90]
 @		_SET_ play: true
+@		_MOVE_ 300, pan: [-100,0]
 @	}
 
 無限ループ中。

--- a/system/sound_control.rb
+++ b/system/sound_control.rb
@@ -132,7 +132,10 @@ class SoundControl  < Control
 
   #サウンドリソースを解放します
   def dispose
-    @entity.dispose
+    if @entity
+      @entity.dispose
+      @entity = nil
+    end
     super
   end
 end

--- a/system/sound_control.rb
+++ b/system/sound_control.rb
@@ -104,13 +104,27 @@ class SoundControl  < Control
   attr_reader :file_path
   def file_path=(file_path)
     @file_path = file_path
-    @entity = Ayame.new(@file_path)
     @midi = true if File.extname(@file_path) == ".mid"
     if midi?
       @entity = Sound.new(@file_path)
     else
       @entity = Ayame.new(@file_path)
+      return if stream?
+      if File.extname(@file_path) == ".ogg"
+        @entity.predecode
+      else
+        @entity.prefetch
+      end
     end
+  end
+
+  attr_reader :stream
+  def stream=(stream)
+    @stream = stream
+  end
+
+  def stream?
+    !!stream
   end
 
   def midi?
@@ -119,6 +133,7 @@ class SoundControl  < Control
 
   def initialize(options, inner_options, root_control)
     super
+    self.stream = options[:stream] || true
     self.file_path = options[:file_path]
 
     #開始位置

--- a/system/sound_control.rb
+++ b/system/sound_control.rb
@@ -1,6 +1,7 @@
 #! ruby -E utf-8
 
 require 'dxruby'
+require 'ayame'
 
 ###############################################################################
 #TSUKASA for DXRuby  α１
@@ -39,25 +40,25 @@ class SoundControl  < Control
   attr_reader :start
   def start=(start)
     @start = start
-    @entity.start = start
+    #@entity.start = start
   end
 
   attr_reader :loop_start
   def loop_start=(loop_start)
     @loop_start = loop_start
-    @entity.loop_start = loop_start if @midi
+    #@entity.loop_start = loop_start if @midi
   end
 
   attr_reader :loop_end
   def loop_end=(loop_end)
     @loop_end = loop_end
-    @entity.loop_end = loop_end if @midi
+    #@entity.loop_end = loop_end if @midi
   end
 
   attr_reader :loop_count
   def loop_count=(loop_count)
     @loop_count = loop_count
-    @entity.loop_count = loop_count
+    #@entity.loop_count = loop_count
   end
 
   attr_reader :volume
@@ -69,20 +70,20 @@ class SoundControl  < Control
   attr_reader :frequency
   def frequency=(args)
     @frequency = args
-    @entity.frequency = args
+    #@entity.frequency = args
   end
 
   attr_reader :pan
   def pan=(args)
     @pan = args
-    @entity.pan = args
+    @entity.set_pan(@pan, 0)
   end
 
   attr_reader :play
   def play=(args)
     @play = args
     if @play
-      @entity.play
+      @entity.play(@loop_count)
     else
       @entity.stop
     end
@@ -91,7 +92,7 @@ class SoundControl  < Control
   attr_reader :file_path
   def file_path=(file_path)
     @file_path = file_path
-    @entity = Sound.new(@file_path)
+    @entity = Ayame.new(@file_path)
     @midi = true if File.extname(@file_path) == ".mid"
   end
 
@@ -108,11 +109,11 @@ class SoundControl  < Control
     #ループ終了位置
     self.loop_end = options[:loop_end] || 0
 
-    #ループ回数（－１なら無限ループ）
+    #ループ回数（０なら無限ループ）
     self.loop_count = options[:loop_count] || 1
 
     #ボリューム／フェード指定
-    self.volume = options[:volume] || 230
+    self.volume = options[:volume] || 90
   end
 
   def siriarize(options = {})


### PR DESCRIPTION
DXRuby::Sound を Ayame に置き換えました。
MIDI のときは DXRuby::Sound を使うようにしています（Ayame はループ位置指定ができないため）。

Ayame の対応にともなって volume の範囲を 0 ～ 100 に、pan の範囲を -100 ～ 100 にしてあります。

## Ayame のインストールについて
Ayame.dll は main.rb と同じディレクトリ内か ruby.exe と同じディレクトリに、ayame.so は `Rubyがインストールされたディレクトリ\lib\ruby\site_ruby\2.1.0\i386-msvcrt`（dxruby.so が置いてある場所です）の中に入れてください。